### PR TITLE
Parse year when tokenizer returns [number: _, month _, number: _]

### DIFF
--- a/lib/chronic.ex
+++ b/lib/chronic.ex
@@ -14,38 +14,38 @@ defmodule Chronic do
       { :ok, %Calendar.NaiveDateTime{day: 2, hour: 13, min: 0, month: 8, sec: 0, usec: nil, year: 2012}, nil }
 
       iex> Chronic.parse("2012-08-02T13:00:00+01:00")
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 13, min: 0, month: 8, sec: 0, usec: nil, year: 2012}, 3600 } 
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 13, min: 0, month: 8, sec: 0, usec: nil, year: 2012}, 3600 }
 
     You can pass an option to define the "current" time for Chronic:
 
       iex> Chronic.parse("aug 2", currently: {{1999, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 0, min: 0, month: 8, sec: 0, usec: 0, year: 1999}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 0, min: 0, month: 8, sec: 0, usec: 0, year: 1999}, 0 }
 
     **All examples here use `currently` so that they are not affected by the passing of time. You may leave the `currently` option off.**
 
       iex> Chronic.parse("aug 2 9am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 0, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 0, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
 
       iex> Chronic.parse("aug 2 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
 
       iex> Chronic.parse("aug 2nd 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
 
       iex> Chronic.parse("aug. 2nd 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
 
       iex> Chronic.parse("2 aug 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
 
       iex> Chronic.parse("2 aug at 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
 
       iex> Chronic.parse("2nd of aug 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
 
       iex> Chronic.parse("2nd of aug at 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
-      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }     
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
   """
   def parse(time, opts \\ []) do
     case Calendar.NaiveDateTime.Parse.iso8601(time) do
@@ -85,6 +85,20 @@ defmodule Chronic do
   # 2 Aug
   defp process([number: day, month: month], [currently: currently]) do
     process_day_and_month(currently, day, month)
+  end
+
+  # 2016 Aug 2
+  defp process([number: day, month: month, number: year], [currently: currently]) when day <= 31 do
+    process_day_and_month_and_year(currently, day, month, year)
+  end
+
+  # 2 Aug 2016
+  defp process([number: year, month: month, number: day], [currently: currently]) when day > 31 do
+    process_day_and_month_and_year(currently, day, month, year)
+  end
+
+  defp process([number: year, month: month, number: day], [currently: currently]) do
+    process_day_and_month_and_year(currently, day, month, year)
   end
 
   # 2 Aug 9am
@@ -212,6 +226,10 @@ defmodule Chronic do
     { :ok, combine(currently, month: month, day: day, time: time) }
   end
 
+  defp process_day_and_month_and_year(currently, day, month, year) do
+    { :ok, combine(currently, month: month, day: day, year: year) }
+  end
+
   defp process_day_of_the_week_with_time(currently, day_of_the_week, time) do
     parts = (date_for(currently) |> find_next_day_of_the_week(day_of_the_week))
 
@@ -237,6 +255,9 @@ defmodule Chronic do
     { :ok, date_for(currently) |> date_with_time(time) }
   end
 
+  defp combine(_, month: month, day: day, year: year) do
+    combine(year: year, month: month, day: day, hour: 0, minute: 0, second: 0, usec: 0) |> change_year_to_four_digit()
+  end
 
   defp combine({{year, _, _}, _}, month: month, day: day) do
     combine(year: year, month: month, day: day, hour: 0, minute: 0, second: 0, usec: 0)
@@ -254,11 +275,43 @@ defmodule Chronic do
     {{ year, month, day }, { hour, minute, second }} |> Calendar.NaiveDateTime.from_erl!(usec)
   end
 
+  # TODO - This is taken from Calendar.DateTime.Parse.rfc822_utc/2.
+  # Remove when Calendar exposes `change_year_to_four_digit/2` publicly.
+  defp change_year_to_four_digit(%Calendar.NaiveDateTime{year: year} = ndt, year_guess \\ 2016) do
+    changed_year = year |> two_to_four_digit(year_guess)
+    %Calendar.NaiveDateTime{ndt | year: changed_year}
+  end
+
+  defp two_to_four_digit(year, year_guess) when year < 100 do
+    closest_year(year, year_guess)
+  end
+  defp two_to_four_digit(year, _), do: year
+
+  defp closest_year(two_digit_year, year_guessing_base) do
+    two_digit_year
+    |> possible_years(year_guessing_base)
+    |> Enum.map(fn year -> {year, abs(year_guessing_base-year)} end)
+    |> Enum.min_by(fn {_year, diff} -> diff end)
+    |> elem(0)
+  end
+
+  defp possible_years(two_digit_year, year_guessing_base) do
+    centuries_for_guessing_base(year_guessing_base)
+    |> Enum.map(&(&1+two_digit_year))
+  end
+
+  # The three centuries closest to the guessing base
+  # if you provide e.g. 2016 it should return [1900, 2000, 2100]
+  defp centuries_for_guessing_base(year_guessing_base) do
+    base_century = year_guessing_base-rem(year_guessing_base, 100)
+    [base_century-100, base_century, base_century+100]
+  end
+
   defp find_next_day_of_the_week(current_date, day_of_the_week) do
-    %{ year: year, month: month, day: day } = Calendar.Date.days_after(current_date) 
+    %{ year: year, month: month, day: day } = Calendar.Date.days_after(current_date)
       |> Enum.take(7)
       |> Enum.find(fn(date) ->
-        Calendar.Date.day_of_week_zb(date) == day_of_the_week
+      Calendar.Date.day_of_week_zb(date) == day_of_the_week
       end)
     [year: year, month: month, day: day]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
-%{"calendar": {:hex, :calendar, "0.14.1"},
+%{"calendar": {:hex, :calendar, "0.14.1", "2e4e74ba55db48a08da46e888152bf8ba151f7ec43817294ea776fcf9d9807f6", [:mix], [{:tzdata, "~> 0.5.7 or ~> 0.1.201603", [hex: :tzdata, optional: false]}]},
   "certifi": {:hex, :certifi, "0.4.0"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.5"},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "hackney": {:hex, :hackney, "1.6.0"},
   "idna": {:hex, :idna, "1.2.0"},
   "metrics": {:hex, :metrics, "1.0.1"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
-  "tzdata": {:hex, :tzdata, "0.1.201603"}}
+  "tzdata": {:hex, :tzdata, "0.1.201603", "9c388ceab3f4714b7d07a9d77ef2f70330e3784a833141ac4926f52237aa0621", [:mix], []}}

--- a/test/month_and_day_test.exs
+++ b/test/month_and_day_test.exs
@@ -66,4 +66,25 @@ defmodule Chronic.MonthAndDayTest do
     assert time == %Calendar.NaiveDateTime{year: current_year, month: 5, day: 28, hour: 5, min: 32, sec: 19, usec: 764}
     assert offset == 0
   end
+
+  test "parsing with year when all numbers are less than or equal to 31" do
+    { :ok, time, offset } = Chronic.parse("20-aug-16")
+    assert time == %Calendar.NaiveDateTime{year: 2016, month: 8, day: 20, hour: 0, min: 0, sec: 0, usec: 0}
+    assert offset == 0
+
+    { :ok, time, offset } = Chronic.parse("16-aug-20")
+    assert time == %Calendar.NaiveDateTime{year: 2020, month: 8, day: 16, hour: 0, min: 0, sec: 0, usec: 0}
+    assert offset == 0
+  end
+
+  test "parsing with year when one number is greater than 31" do
+    { :ok, time, offset } = Chronic.parse("2016-aug-20")
+    assert time == %Calendar.NaiveDateTime{year: 2016, month: 8, day: 20, hour: 0, min: 0, sec: 0, usec: 0}
+    assert offset == 0
+
+    { :ok, time, offset } = Chronic.parse("16-aug-2020")
+    assert time == %Calendar.NaiveDateTime{year: 2020, month: 8, day: 16, hour: 0, min: 0, sec: 0, usec: 0}
+    assert offset == 0
+  end
+
 end


### PR DESCRIPTION
https://github.com/radar/chronic/issues/2

This checks if either numbers are greater than 31 to determine the year;
otherwise we default to the tail of the keyword list.
