### PR TITLE
Allow a space between time and AM/PM, eg "9:15 am"

### DIFF
--- a/lib/chronic.ex
+++ b/lib/chronic.ex
@@ -46,6 +46,9 @@ defmodule Chronic do
 
       iex> Chronic.parse("2nd of aug at 9:15am", currently: {{2016, 1, 1}, {0,0,0}})
       { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
+
+      iex> Chronic.parse("2nd of aug at 9:15 am", currently: {{2016, 1, 1}, {0,0,0}})
+      { :ok, %Calendar.NaiveDateTime{day: 2, hour: 9, min: 15, month: 8, sec: 0, usec: 0, year: 2016}, 0 }
   """
   def parse(time, opts \\ []) do
     case Calendar.NaiveDateTime.Parse.iso8601(time) do
@@ -64,7 +67,7 @@ defmodule Chronic do
   end
 
   defp preprocess(time) do
-    String.replace(time, "-", " ") |> String.split(" ") |> Chronic.Tokenizer.tokenize
+    String.replace(time, "-", " ") |> String.replace(~r/(?<=\d)\s+(?=[a|p]m\b)/i, "") |> String.split(" ") |> Chronic.Tokenizer.tokenize
   end
 
   # Aug 2

--- a/test/month_and_day_test.exs
+++ b/test/month_and_day_test.exs
@@ -49,6 +49,18 @@ defmodule Chronic.MonthAndDayTest do
     assert offset == 0
   end
 
+  test "month with day, and PM time with space formatting" do
+    { :ok, time, offset } = Chronic.parse("aug 3 5:26 pm")
+    assert time == %Calendar.NaiveDateTime{year: current_year, day: 3, hour: 17, min: 26, month: 8, sec: 0, usec: 0}
+    assert offset == 0
+  end
+
+  test "month with day, and AM time with space formatting" do
+    { :ok, time, offset } = Chronic.parse("aug 3 9:26 am")
+    assert time == %Calendar.NaiveDateTime{year: current_year, month: 8, day: 3, hour: 9, min: 26, sec: 0, usec: 0}
+    assert offset == 0
+  end
+
   test "month with day, with 'at' AM time" do
     { :ok, time, offset } = Chronic.parse("aug 3 at 9:26am")
     assert time == %Calendar.NaiveDateTime{year: current_year, month: 8, day: 3, hour: 9, min: 26, sec: 0, usec: 0}

--- a/test/plain_time_test.exs
+++ b/test/plain_time_test.exs
@@ -9,6 +9,13 @@ defmodule Chronic.PlainTimeTest do
     assert offset == 0
   end
 
+  test "11 am" do
+    { :ok, time, offset } = Chronic.parse("11 am", currently: frozen_time)
+
+    assert time == %Calendar.NaiveDateTime{year: 2015, month: 5, day: 9, hour: 11, min: 0, sec: 0, usec: 0}
+    assert offset == 0
+  end
+
   test "10 to 8" do
     { :ok, time, offset } = Chronic.parse("10 to 8", currently: frozen_time)
 
@@ -18,6 +25,13 @@ defmodule Chronic.PlainTimeTest do
 
   test "10 to 8pm" do
     { :ok, time, offset } = Chronic.parse("10 to 8pm", currently: frozen_time)
+
+    assert time == %Calendar.NaiveDateTime{year: 2015, month: 5, day: 9, hour: 19, min: 50, sec: 0, usec: 0}
+    assert offset == 0
+  end
+
+  test "10 to 8 pm" do
+    { :ok, time, offset } = Chronic.parse("10 to 8 pm", currently: frozen_time)
 
     assert time == %Calendar.NaiveDateTime{year: 2015, month: 5, day: 9, hour: 19, min: 50, sec: 0, usec: 0}
     assert offset == 0


### PR DESCRIPTION
I want to use Chronic in a project, but all of the dates I want to parse have spaces between the time and the am/pm, like "9:15 am". As coded, Chronic only supports "9:15am". I wrote a regex to reformat my times into Chronic compatible, but thought it would be useful to other people as well, so I added it to the Chronic codebase.

I did look into handling it as another token, but that seemed to duplicate the am/pm logic in two places, so I kept it as a somewhat terrifying regex in the preprocessor. It might be nice to extract my String.replace into its own private function with an explanatory name, since that regex with all the lookahead/behind syntax is pretty hard to figure out at a glance? 
