### PR TITLE
Properly parse "12am" and "12pm"

### DIFF
--- a/lib/chronic/tokenizer.ex
+++ b/lib/chronic/tokenizer.ex
@@ -59,11 +59,16 @@ defmodule Chronic.Tokenizer do
       "am_or_pm" => am_or_pm
     } = Regex.named_captures(time_regex, token)
     hour = String.to_integer(hour)
-    hour = if am_or_pm == "pm", do: hour + 12, else: hour
+    hour = shift_hour(hour, am_or_pm)
     minute = if minute == "", do: 0, else: String.to_integer(minute)
     second = if second == "", do: 0, else: String.to_integer(second)
     microsecond = if microsecond == "", do: 0, else: String.to_integer(microsecond)
 
     { :time, [hour: hour, minute: minute, second: second, microsecond: {microsecond,6}] }
   end
+
+  defp shift_hour(12, "am"), do: 0
+  defp shift_hour(12, "pm"), do: 12
+  defp shift_hour(hr, "pm"), do: hr + 12
+  defp shift_hour(hr, _   ), do: hr
 end

--- a/test/plain_time_test.exs
+++ b/test/plain_time_test.exs
@@ -16,6 +16,20 @@ defmodule Chronic.PlainTimeTest do
     assert offset == 0
   end
 
+  test "12am" do
+    { :ok, time, offset } = Chronic.parse("12am", currently: frozen_time)
+
+    assert time == %NaiveDateTime{year: 2015, month: 5, day: 9, hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
+    assert offset == 0
+  end
+
+  test "12pm" do
+    { :ok, time, offset } = Chronic.parse("12pm", currently: frozen_time)
+
+    assert time == %NaiveDateTime{year: 2015, month: 5, day: 9, hour: 12, minute: 0, second: 0, microsecond: {0, 6}}
+    assert offset == 0
+  end
+
   test "10 to 8" do
     { :ok, time, offset } = Chronic.parse("10 to 8", currently: frozen_time)
 


### PR DESCRIPTION
Currently, "12am" is being parsed into 12-noon, and "12pm" cannot not be parsed at all, because the code is attempting to parse it into the hour 24, resulting in an {:error, :invalid_datetime} from Calendar NDT