### PR TITLE
Choose same day when relative time is later than current

### DIFF
--- a/lib/chronic.ex
+++ b/lib/chronic.ex
@@ -275,7 +275,25 @@ defmodule Chronic do
   end
 
   defp process_day_of_the_week_with_time(currently, day_of_the_week, time) do
-    parts = (date_for(currently) |> find_next_day_of_the_week(day_of_the_week))
+    current_date_erl = date_for(currently)
+    current_date_day_of_week =
+      current_date_erl
+      |> Date.from_erl!()
+      |> Date.day_of_week()
+    current_time = NaiveDateTime.from_erl!(currently)
+
+    [hour: hours, minute: minutes, second: seconds, microsecond: _] = time
+    parsed_time = NaiveDateTime.from_erl!({current_date_erl, {hours, minutes, seconds}})
+
+    is_same_day = current_date_day_of_week == day_of_the_week
+    is_later_today = is_same_day && current_time < parsed_time
+
+    parts = if is_later_today do
+      %{ year: year, month: month, day: day } = Date.from_erl!(current_date_erl)
+      [year: year, month: month, day: day]
+    else
+      (current_date_erl |> find_next_day_of_the_week(day_of_the_week))
+    end
 
     combine(parts ++ time)
   end

--- a/test/relative_test.exs
+++ b/test/relative_test.exs
@@ -50,6 +50,18 @@ defmodule Chronic.RelativeTest do
     assert offset == 0
   end
 
+  test "Tuesday 4pm - at 9am same day" do
+    { :ok, time, offset } = Chronic.parse("Tuesday 4pm", currently: {{2018, 9, 25}, {9, 0, 0}})
+    assert time == %NaiveDateTime{year: 2018, month: 9, day: 25, hour: 16, minute: 0, second: 0, microsecond: {0, 6}}
+    assert offset == 0
+  end
+
+  test "Tuesday 4pm - at 4pm same day" do
+    { :ok, time, offset } = Chronic.parse("Tuesday 4pm", currently: {{2018, 9, 25}, {16, 0, 0}})
+    assert time == %NaiveDateTime{year: 2018, month: 10, day: 2, hour: 16, minute: 0, second: 0, microsecond: {0, 6}}
+    assert offset == 0
+  end
+
   test "Tuesday at 9am" do
     { :ok, time, offset } = Chronic.parse("Tuesday at 9am", currently: frozen_time())
     assert time == %NaiveDateTime{year: 2015, month: 5, day: 12, hour: 9, minute: 0, second: 0, microsecond: {0, 6}}


### PR DESCRIPTION
Hi! Sorry for not opening an issue first. I had a specific use case to tailor
this to so I hacked at getting this to work, but still within the confines of the
tests I've provided to demonstrate what I was running up against.

In cases such as "Monday 4pm", Chronic currently does not give the same
day when the time is later than what is given in `currently`. For
example, "Monday 4pm", when `currently` is a Monday and at 7am, will yield
_next_ Monday, but "Tuesday 4pm" will yield the following day. I've provided 
a failing test to demonstrate as the first commit.

This was a bit of a surprise and I've adjusted the code to first check
that if we are on the same day of week and the time is later to return
back the requested time for the current day rather than the next
matching day of week.
