### PR TITLE
Fix parsing 'Sunday 12pm'

### DIFF
--- a/lib/chronic.ex
+++ b/lib/chronic.ex
@@ -390,7 +390,13 @@ defmodule Chronic do
 
     tomorrow = Date.add(current_date, 1)
 
-    if Date.day_of_week(tomorrow) == day_of_the_week do
+    # This is needed as Date.day_of_week is based on Monday = 1 to Sunday = 7
+    # The Chronic week, however, has Monday = 1, Saturday = 6, and Sunday = 0
+    tomorrow_day_of_week =
+      with dow <- Date.day_of_week(tomorrow),
+        do: if Date.day_of_week(tomorrow) == 7, do: 0, else: dow
+
+    if tomorrow_day_of_week == day_of_the_week do
       %{year: year, month: month, day: day} = tomorrow
       [year: year, month: month, day: day]
     else

--- a/test/relative_test.exs
+++ b/test/relative_test.exs
@@ -68,6 +68,12 @@ defmodule Chronic.RelativeTest do
     assert offset == 0
   end
 
+  test "Sunday 12pm" do
+    {:ok, time, offset} = Chronic.parse("Sunday 12pm", currently: {{2018, 9, 28}, {8, 0, 0}})
+    assert time == %NaiveDateTime{year: 2018, month: 9, day: 30, hour: 12, minute: 0, second: 0, microsecond: {0, 6}}
+    assert offset == 0
+  end
+
   test "6 in the morning" do
     {:ok, time, offset} = Chronic.parse("6 in the morning", currently: frozen_time())
     assert time == %NaiveDateTime{year: 2015, month: 5, day: 9, hour: 6, minute: 0, second: 0, microsecond: {0, 6}}


### PR DESCRIPTION
Hey again!

Looks like Chronic is expecting weeks to start from Sunday and go from 0-6, but the standard lib in Elixir for dates (`Date`) treats them as going from 1-7 and starting on a Monday. See [here](https://hexdocs.pm/elixir/Date.html#day_of_week/1).

This meant that it would continue to try to find the next day and would never match Sunday. Here's the exact test case output from the failing test I've provided:

```
  1) test Sunday 12pm (Chronic.RelativeTest)
     test/relative_test.exs:71
     ** (FunctionClauseError) no function clause matching in Calendar.ISO.date_from_iso_days/1

     The following arguments were given to Calendar.ISO.date_from_iso_days/1:

         # 1
         3652425

     Attempted function clauses (showing 2 out of 2):

         def date_from_iso_days(days) when is_integer(days) and (days >= 0 and days <= 3652424)
         def date_from_iso_days(days) when is_integer(days) and is_integer(-3652059) and is_integer(-1) and (-3652059 <= -1 and (days >= -3652059 and days <= -1) or -1 < -3652059 and (days <= -3652059 and days >= -1))

     code: {:ok, time, offset} = Chronic.parse("Sunday 12pm", currently: {{2018, 9, 28}, {8, 0, 0}})
     stacktrace:
       (elixir) lib/calendar/iso.ex:211: Calendar.ISO.date_from_iso_days/1
       (elixir) lib/calendar/date.ex:613: Date.from_iso_days/2
       (chronic) lib/chronic.ex:391: Chronic.find_next_day_of_the_week/2
       (chronic) lib/chronic.ex:302: Chronic.process_day_of_the_week_with_time/3
       (chronic) lib/chronic.ex:80: Chronic.parse_natural_language/2
       test/relative_test.exs:72: (test)
```

3652425 is how many days it takes to fill 10k years, which seems to be the upper bound for this function that `Date.add` relies on. 

As I've noted in my commit descriptions, I think one of two things probably needs to happen here for actually dealing with the root cause which is either shifting to days of the week as they're handled in the standard library functions or possibly documenting this behaviour as a shift away from that. It may be worth trying out some property based testing to catch a lot more cases, too, but that's just an aside. 🙂 
